### PR TITLE
VII: Add external login support

### DIFF
--- a/AuthorizationServer/AuthorizationServer.csproj
+++ b/AuthorizationServer/AuthorizationServer.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
-    <PackageReference Include="OpenIddict" Version="3.1.1" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="OpenIddict" Version="5.7.0" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="5.7.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.7.0" />
   </ItemGroup>
 
 </Project>

--- a/AuthorizationServer/AuthorizationServer.sln
+++ b/AuthorizationServer/AuthorizationServer.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35027.167
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthorizationServer", "AuthorizationServer.csproj", "{A5AAC4EA-8B62-42F8-9B8E-E64F095590FB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5AAC4EA-8B62-42F8-9B8E-E64F095590FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5AAC4EA-8B62-42F8-9B8E-E64F095590FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5AAC4EA-8B62-42F8-9B8E-E64F095590FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5AAC4EA-8B62-42F8-9B8E-E64F095590FB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E0468738-6D92-4FEB-B249-9B9C1718508B}
+	EndGlobalSection
+EndGlobal

--- a/AuthorizationServer/Controllers/AccountController.cs
+++ b/AuthorizationServer/Controllers/AccountController.cs
@@ -19,7 +19,17 @@ namespace AuthorizationServer.Controllers
             return View();
         }
 
-        [HttpPost]
+		[HttpGet]
+		[AllowAnonymous]
+		public IActionResult LoginEntra(string returnUrl = null)
+		{
+			ViewData["ReturnUrl"] = returnUrl;
+
+			return Challenge("Entra");
+			//OpenIddict will use the Challenge result to talk to the configured provider automatically.
+		}
+
+		[HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(LoginViewModel model)

--- a/AuthorizationServer/Controllers/AuthorizationController.cs
+++ b/AuthorizationServer/Controllers/AuthorizationController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -10,7 +10,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
+using OpenIddict.Client.AspNetCore;
 using OpenIddict.Server.AspNetCore;
+using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace AuthorizationServer.Controllers
 {
@@ -23,7 +25,7 @@ namespace AuthorizationServer.Controllers
         {
             var request = HttpContext.GetOpenIddictServerRequest() ??
                           throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
-            
+
             // Retrieve the user principal stored in the authentication cookie.
             var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
 
@@ -58,7 +60,7 @@ namespace AuthorizationServer.Controllers
             // Signing in with the OpenIddict authentiction scheme trigger OpenIddict to issue a code (which can be exchanged for an access token)
             return SignIn(claimsPrincipal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
-        
+
         [HttpPost("~/connect/token")]
         public async Task<IActionResult> Exchange()
         {
@@ -90,7 +92,7 @@ namespace AuthorizationServer.Controllers
                 // Retrieve the claims principal stored in the authorization code
                 claimsPrincipal = (await HttpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)).Principal;
             }
-            
+
             else if (request.IsRefreshTokenGrantType())
             {
                 // Retrieve the claims principal stored in the refresh token.
@@ -105,7 +107,7 @@ namespace AuthorizationServer.Controllers
             // Returning a SignInResult will ask OpenIddict to issue the appropriate access/identity tokens.
             return SignIn(claimsPrincipal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
-        
+
         [Authorize(AuthenticationSchemes = OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)]
         [HttpGet("~/connect/userinfo")]
         public async Task<IActionResult> Userinfo()
@@ -118,6 +120,63 @@ namespace AuthorizationServer.Controllers
                 Occupation = "Developer",
                 Age = 43
             });
+        }
+
+        //https://documentation.openiddict.com/guides/getting-started/integrating-with-a-remote-server-instance.html
+        // You can handle providers independently, if perhaps you want to add certain claims
+        // depending on which authority the user used to sign in, by adding a provider parameter to this method
+        // and then doing some custom logic
+        [HttpGet("~/callback/login/{provider}"), HttpPost("~/callback/login/{provider}"), IgnoreAntiforgeryToken]
+        public async Task<ActionResult> LogInCallback()
+        {
+            // Retrieve the authorization data validated by OpenIddict as part of the callback handling.
+            var result = await HttpContext.AuthenticateAsync(OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+
+            // Important: if the remote server doesn't support OpenID Connect and doesn't expose a userinfo endpoint,
+            // result.Principal.Identity will represent an unauthenticated identity and won't contain any user claim.
+            //
+            // Such identities cannot be used as-is to build an authentication cookie in ASP.NET Core (as the
+            // antiforgery stack requires at least a name claim to bind CSRF cookies to the user's identity) but
+            // the access/refresh tokens can be retrieved using result.Properties.GetTokens() to make API calls.
+            if (result.Principal is not ClaimsPrincipal { Identity.IsAuthenticated: true })
+            {
+                throw new InvalidOperationException("The external authorization data cannot be used for authentication.");
+            }
+
+            // Build an identity based on the external claims and that will be used to create the authentication cookie.
+            var identity = new ClaimsIdentity(authenticationType: "ExternalLogin");
+
+            // By default, OpenIddict will automatically try to map the email/name and name identifier claims from
+            // their standard OpenID Connect or provider-specific equivalent, if available. If needed, additional
+            // claims can be resolved from the external identity and copied to the final authentication cookie.
+            identity.SetClaim(ClaimTypes.Email, result.Principal.GetClaim(ClaimTypes.Email))
+                    .SetClaim(ClaimTypes.Name, result.Principal.GetClaim(ClaimTypes.Name))
+                    .SetClaim(ClaimTypes.NameIdentifier, result.Principal.GetClaim(ClaimTypes.NameIdentifier));
+
+            // Preserve the registration identifier to be able to resolve it later.
+            identity.SetClaim(Claims.Private.RegistrationId, result.Principal.GetClaim(Claims.Private.RegistrationId));
+
+            // Build the authentication properties based on the properties that were added when the challenge was triggered.
+            var properties = new AuthenticationProperties(result.Properties.Items)
+            {
+                RedirectUri = result.Properties.RedirectUri ?? "/"
+            };
+
+            // If needed, the tokens returned by the authorization server can be stored in the authentication cookie.
+            //
+            // To make cookies less heavy, tokens that are not used are filtered out before creating the cookie.
+            properties.StoreTokens(result.Properties.GetTokens().Where(token => token.Name is
+                // Preserve the access, identity and refresh tokens returned in the token response, if available.
+                OpenIddictClientAspNetCoreConstants.Tokens.BackchannelAccessToken or
+                OpenIddictClientAspNetCoreConstants.Tokens.BackchannelIdentityToken or
+                OpenIddictClientAspNetCoreConstants.Tokens.RefreshToken));
+
+            // Ask the default sign-in handler to return a new cookie and redirect the
+            // user agent to the return URL stored in the authentication properties.
+            //
+            // For scenarios where the default sign-in handler configured in the ASP.NET Core
+            // authentication options shouldn't be used, a specific scheme can be specified here.
+            return SignIn(new ClaimsPrincipal(identity), properties);
         }
     }
 }

--- a/AuthorizationServer/Views/Account/Login.cshtml
+++ b/AuthorizationServer/Views/Account/Login.cshtml
@@ -9,3 +9,5 @@
         <button type="submit" class="btn btn-dark btn-block mt-3">Login</button>
     </p>
 </form>
+Or
+<p><a class="btn btn-sm btn-dark" asp-controller="Account" asp-action="LoginEntra">Sign in using Entra</a></p>

--- a/AuthorizationServer/Views/Home/Index.cshtml
+++ b/AuthorizationServer/Views/Home/Index.cshtml
@@ -25,5 +25,6 @@
     <div>
         <p>You are not signed in</p>
         <p><a class="btn btn-sm btn-dark" asp-controller="Account" asp-action="Login">Sign in</a></p>
+        <p><a class="btn btn-sm btn-dark" asp-controller="Account" asp-action="LoginEntra">Sign in using Entra</a></p>
     </div>
 }


### PR DESCRIPTION
The demo in this sample is fantastic, and was 90% of the way there for what I needed. Not using ASPNET Identity was a requirement for me, since I have an existing database of users I need to authenticate locally with, but also support external federated authentication.

However, I could not find a complete sample that demonstrates this particular workflow anywhere (and didn't use ASPNET Identity). This took me the better part of the week to learn OpenID Connect, refresh on MVC, and to figure out and wrap my head around OpenIddict. So, hopefully to save the next dev some time, I tender for your consideration, part VII; Adding an external login provider.

In this PR, I updated the OpenIddict packages to .NET 8 which is the current LTS .NET release from Microsoft, and updated the OpenIddict packages to latest and greatest. 

The key changes are:
- Adding an OpenIddict Client in Startup.cs, which includes the Microsoft Entra provider (or which ever one you want)
- Adding a new route in the AccountController for LoginEntra that returns Challenge, which is the magic sauce for having OpenIddict automagically authenticate the request with the external provider. 
- Adding a login callback to AuthorizationController, which handles the post-back from Entra after the user successfully authenticates. This is taken directly from the official OpenIddict documentation
- Add a button on the home page and login page to ask a user to sign in using Entra. 